### PR TITLE
Fix 'module not found' for running anything

### DIFF
--- a/fastwsgi.py
+++ b/fastwsgi.py
@@ -87,7 +87,9 @@ def import_from_string(import_str):
         raise ImportError("Import string should be in the format <module>:<attribute>")
 
     try:
-        module = importlib.import_module(module_str)
+        spec = importlib.util.spec_from_file_location(module_str, f"{module_str}.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
         for attr_str in attrs_str.split("."):
             module = getattr(module, attr_str)
     except AttributeError:


### PR DESCRIPTION
Attempting to run even something as simple as the example in the README results in a "module not found" error. This PR fixes this by importing the module via path instead of using `importlib.import_module`.

From my testing, this commit works perfectly.
If you can't replicate this bug, or if it causes other issues, then ignore this PR.