### PR TITLE
Remove pkg_resources for support Python 3.12+

### DIFF
--- a/fastwsgi.py
+++ b/fastwsgi.py
@@ -2,11 +2,12 @@ import os
 import sys
 import signal
 import importlib
+import importlib.util
+import importlib.metadata
 import click
 import _fastwsgi
-from pkg_resources import get_distribution
 
-__version__ = get_distribution("fastwsgi").version
+__version__ = importlib.metadata.version("fastwsgi")
 
 LL_DISABLED    = 0
 LL_FATAL_ERROR = 1
@@ -121,7 +122,7 @@ def import_from_string(import_str):
 # -------------------------------------------------------------------------------------
 
 @click.command()
-@click.version_option(version=get_distribution("fastwsgi").version, message="%(version)s")
+@click.version_option(version=__version__, message="%(version)s")
 @click.option("--host", help="Host the socket is bound to.", type=str, default=server.host, show_default=True)
 @click.option("-p", "--port", help="Port the socket is bound to.", type=int, default=server.port, show_default=True)
 @click.option("-l", "--loglevel", help="Logging level.", type=int, default=server.loglevel, show_default=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
 from click.testing import CliRunner
-from pkg_resources import get_distribution
+import importlib.metadata
 
 from fastwsgi import run_from_cli
 
@@ -23,7 +23,7 @@ class TestCLI:
     def test_version(self):
         result = call_fastwsgi(parameters=["--version"])
         assert result.exit_code == 0
-        assert result.output.strip() == get_distribution("fastwsgi").version
+        assert result.output.strip() == importlib.metadata.version("fastwsgi")
 
     def test_run_from_cli_invalid_module(self):
         result = call_fastwsgi(arguments=["module:wrong"])


### PR DESCRIPTION
Almost a complete copy of this PR: https://github.com/jamesroberts/fastwsgi/pull/58
But in my version the extra bracket is missing.